### PR TITLE
Deprecate "Promise" action creators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ e2e/protos/readinglist/*.ts
 e2e/protos/readinglist/*.js
 e2e/protos/BasicState
 
+
+*.swo
+*.swp

--- a/e2e/src/action.test.ts
+++ b/e2e/src/action.test.ts
@@ -77,16 +77,11 @@ describe('Action Type Tests', () => {
     it('should follow the same format for all the type strings', () => {
       let payload : string = "BookOfTheMonth"
       let cruds : string[] = ["create", "update", "delete", "get"]
-      let effects : string[] = ["Request", "RequestPromise", "Success", "Failure", "Cancel"]
+      let effects : string[] = ["Request", "Success", "Failure", "Cancel"]
       for(var cIndex : number = 0; cIndex < cruds.length; cIndex++){
         for(var eIndex : number = 0; eIndex < effects.length; eIndex++){
-          if(eIndex == 1){ // add underscore for promise
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_REQUEST_PROMISE")
-          } else {
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
-          }
+          expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
+            .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
         }
       }
     })
@@ -95,16 +90,11 @@ describe('Action Type Tests', () => {
     it('should follow the same format for all the type strings', () => {
       let payload : string = "Library"
       let cruds : string[] = ["create", "update", "delete", "list"]
-      let effects : string[] = ["Request", "RequestPromise", "Success", "Failure", "Cancel"]
+      let effects : string[] = ["Request", "Success", "Failure", "Cancel"]
       for(var cIndex : number = 0; cIndex < cruds.length; cIndex++){
         for(var eIndex : number = 0; eIndex < effects.length; eIndex++){
-          if(eIndex == 1){ // add underscore for promise TODO: might fail in tsc
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_REQUEST_PROMISE")
-          } else {
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
-          }
+          expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
+            .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
         }
       }
     })
@@ -133,6 +123,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.createBookOfTheMonthRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Single Entity Request Promise', () => {
@@ -140,7 +131,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.createBookOfTheMonthRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ bookOfTheMonth: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Single Entity Success', () => {
@@ -165,6 +157,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.createLibraryRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Repeated Entity Request Promise', () => {
@@ -172,7 +165,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.createLibraryRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ library: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Repeated Entity Success', () => {
@@ -200,6 +194,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.getBookOfTheMonthRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Single Entity Request Promise', () => {
@@ -207,7 +202,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.getBookOfTheMonthRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ bookOfTheMonth: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Single Entity Success', () => {
@@ -232,6 +228,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.listLibraryRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Repeated Entity Request Promise', () => {
@@ -239,7 +236,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.listLibraryRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ library: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Repeated Entity Success', () => {
@@ -272,6 +270,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.updateBookOfTheMonthRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Single Entity Request Promise', () => {
@@ -279,7 +278,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.updateBookOfTheMonthRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ bookOfTheMonth: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Single Entity Success', () => {
@@ -304,6 +304,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.updateLibraryRequest(bookObj, newBookObj);
         expect(result.payload).toEqual({ prev: bookObj, updated: newBookObj });
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Repeated Entity Request Promise', () => {
@@ -311,12 +312,12 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.updateLibraryRequestPromise(bookObj, newBookObj, resolve, reject);
-        expect(result.payload).toEqual({ prev: bookObj, updated: newBookObj, resolve, reject });
+        expect(result.payload).toEqual({ prev: bookObj, updated: newBookObj });
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Repeated Entity Success', () => {
-      it('should return the book as the payload', () => {
-        let result = ProtocActions.updateLibrarySuccess({ prev: bookObj, updated: newBookObj });
+      it('should return the book as the payload', () => { let result = ProtocActions.updateLibrarySuccess({ prev: bookObj, updated: newBookObj });
         expect(result.payload).toEqual({ prev: bookObj, updated: newBookObj });
       })
     })
@@ -339,6 +340,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.deleteBookOfTheMonthRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Single Entity Request Promise', () => {
@@ -346,7 +348,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.deleteBookOfTheMonthRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ bookOfTheMonth: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Single Entity Success', () => {
@@ -371,6 +374,7 @@ describe('Action Payload Tests', () => {
       it('should return the book as the payload', () => {
         let result = ProtocActions.deleteLibraryRequest(bookObj);
         expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
       })
     })
     describe('Repeated Entity Request Promise', () => {
@@ -378,7 +382,8 @@ describe('Action Payload Tests', () => {
         let resolve = function(){};
         let reject = function(){};
         let result = ProtocActions.deleteLibraryRequestPromise(bookObj, resolve, reject);
-        expect(result.payload).toEqual({ library: bookObj, resolve, reject });
+        expect(result.payload).toEqual(bookObj);
+        expect(result.meta).toEqual({ resolve, reject });
       })
     })
     describe('Repeated Entity Success', () => {
@@ -429,16 +434,11 @@ describe('Custom Action Tests', () => {
     it('should follow the same format for all the type strings', () => {
       let payload : string = "ErrorBook"
       let cruds : string[] = ["custom"]
-      let effects : string[] = ["Request", "RequestPromise", "Success", "Failure", "Cancel"]
+      let effects : string[] = ["Request", "Success", "Failure", "Cancel"]
       for(var cIndex : number = 0; cIndex < cruds.length; cIndex++){
         for(var eIndex : number = 0; eIndex < effects.length; eIndex++){
-          if(eIndex == 1){ // add underscore for promise
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_REQUEST_PROMISE")
-          } else {
-            expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
-              .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
-          }
+          expect(ProtocActions[cruds[cIndex]+payload+effects[eIndex]]().type)
+            .toBe("PROTOC_" + cruds[cIndex].toUpperCase() + "_" + payload.toUpperCase() + "_" + effects[eIndex].toUpperCase())
         }
       }
     })
@@ -460,12 +460,14 @@ describe('Custom Action Tests', () => {
     it('should return the book as the payload', () => {
       let result = ProtocActions.customErrorBookRequest(bookObj);
       expect(result.payload).toEqual(bookObj);
+      expect(result.meta).toEqual({ resolve: undefined, reject: undefined });
     })
     it('should return the book as the payload', () => {
       let resolve = function(){};
       let reject = function(){};
       let result = ProtocActions.customErrorBookRequestPromise(bookObj, resolve, reject);
-      expect(result.payload).toEqual({ errorBook: bookObj, resolve, reject });
+      expect(result.payload).toEqual(bookObj);
+      expect(result.meta).toEqual({ resolve, reject });
     })
     it('should return the book as the payload', () => {
       let result = ProtocActions.customErrorBookSuccess(bookObj);

--- a/generator/action.go
+++ b/generator/action.go
@@ -51,17 +51,16 @@ import * as ProtocTypes from './protoc_types_pb';
 }
 
 const createTemplate = `{{range $i, $e := .}}
-export const create{{$e.JsonName | title}}Request = createAction('PROTOC_CREATE_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-});
-
-export const create{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_CREATE_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const create{{$e.JsonName | title}}Request = createAction('PROTOC_CREATE_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return (
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject });
+		resolve?: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject });
 });
+
+// deprecated
+export const create{{$e.JsonName | title}}RequestPromise = create{{$e.JsonName | title}}Request;
 
 export const create{{$e.JsonName | title}}Success = createAction('PROTOC_CREATE_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
 	return ({{$e.JsonName}}: {{$e.OutputType}}) => resolve({{$e.JsonName}})
@@ -75,26 +74,20 @@ export const create{{$e.JsonName | title}}Cancel = createAction('PROTOC_CREATE_{
 `
 
 const updateTemplate = `{{range $i, $e := .}}
-{{if $e.Repeat}}
-export const update{{$e.JsonName | title}}Request = createAction('PROTOC_UPDATE_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return (prev: {{$e.InputType}}, updated: {{$e.InputType}}) => resolve({prev, updated})
-}){{else}}
-export const update{{$e.JsonName | title}}Request = createAction('PROTOC_UPDATE_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-}){{end}}
-
-export const update{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_UPDATE_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const update{{$e.JsonName | title}}Request = createAction('PROTOC_UPDATE_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return ({{if $e.Repeat}}
 		prev: {{$e.InputType}},
 		updated: {{$e.InputType}},
-		resolve: (prev: {{$e.InputType}}, updated: {{$e.InputType}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ prev, updated, resolve, reject }){{else}}
+		resolve?: (prev: {{$e.InputType}}, updated: {{$e.InputType}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({ prev, updated }, { resolve, reject }){{else}}
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject }){{end}}
+		resolve?: (payload: {{$e.OutputType}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject }){{end}}
 });
+
+export const update{{$e.JsonName | title}}RequestPromise = update{{$e.JsonName | title}}Request
 
 {{if $e.Repeat}}
 export const update{{$e.JsonName | title}}Success = createAction('PROTOC_UPDATE_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
@@ -112,17 +105,16 @@ export const update{{$e.JsonName | title}}Cancel = createAction('PROTOC_UPDATE_{
 `
 
 const getTemplate = `{{range $i, $e := .}}
-export const get{{$e.JsonName | title}}Request = createAction('PROTOC_GET_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-});
-
-export const get{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_GET_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const get{{$e.JsonName | title}}Request = createAction('PROTOC_GET_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return (
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject });
+		resolve?: (payload: {{$e.OutputType}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject });
 });
+
+// deprecated
+export const get{{$e.JsonName | title}}RequestPromise = get{{$e.JsonName | title}}Request;
 
 export const get{{$e.JsonName | title}}Success = createAction('PROTOC_GET_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
 	return ({{$e.JsonName}}: {{$e.OutputType}}) => resolve({{$e.JsonName}})
@@ -136,17 +128,16 @@ export const get{{$e.JsonName | title}}Cancel = createAction('PROTOC_GET_{{$e.Js
 `
 
 const listTemplate = `{{range $i, $e := .}}
-export const list{{$e.JsonName | title}}Request = createAction('PROTOC_LIST_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-});
-
-export const list{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_LIST_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const list{{$e.JsonName | title}}Request = createAction('PROTOC_LIST_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return (
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}[]) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject });
+		resolve?: (payload: {{$e.OutputType}}[]) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject });
 });
+
+// deprecated
+export const list{{$e.JsonName | title}}RequestPromise = list{{$e.JsonName | title}}Request;
 
 export const list{{$e.JsonName | title}}Success = createAction('PROTOC_LIST_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
 	return ({{$e.JsonName}}: {{$e.OutputType}}[]) => resolve({{$e.JsonName}})
@@ -160,17 +151,16 @@ export const list{{$e.JsonName | title}}Cancel = createAction('PROTOC_LIST_{{$e.
 `
 
 const deleteTemplate = `{{range $i, $e := .}}
-export const delete{{$e.JsonName | title}}Request = createAction('PROTOC_DELETE_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-});
-
-export const delete{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_DELETE_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const delete{{$e.JsonName | title}}Request = createAction('PROTOC_DELETE_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return (
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject });
+		resolve?: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject });
 });
+
+// deprecated
+export const delete{{$e.JsonName | title}}RequestPromise = delete{{$e.JsonName | title}}Request;
 
 export const delete{{$e.JsonName | title}}Success = createAction('PROTOC_DELETE_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
 	return ({{$e.JsonName}}: {{$e.OutputType}}) => resolve({{$e.JsonName}})
@@ -184,17 +174,16 @@ export const delete{{$e.JsonName | title}}Cancel = createAction('PROTOC_DELETE_{
 `
 
 const customTemplate = `{{range $i, $e := .}}
-export const custom{{$e.JsonName | title}}Request = createAction('PROTOC_CUSTOM_{{$e.JsonName | caps}}_REQUEST', (resolve) => {
-	return ({{$e.JsonName}}: {{$e.InputType}}) => resolve({{$e.JsonName}})
-});
-
-export const custom{{$e.JsonName | title}}RequestPromise = createAction('PROTOC_CUSTOM_{{$e.JsonName | caps}}_REQUEST_PROMISE', (res) => {
+export const custom{{$e.JsonName | title}}Request = createAction('PROTOC_CUSTOM_{{$e.JsonName | caps}}_REQUEST', (res) => {
 	return (
 		{{$e.JsonName}}: {{$e.InputType}},
-		resolve: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
-		reject: (error: NodeJS.ErrnoException) => void,
-	) => res({ {{$e.JsonName}}, resolve, reject });
+		resolve?: (payload: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => void,
+		reject?: (error: NodeJS.ErrnoException) => void,
+	) => res({{$e.JsonName}}, { resolve, reject });
 });
+
+//deprecated
+export const custom{{$e.JsonName | title}}RequestPromise = custom{{$e.JsonName | title}}Request;
 
 export const custom{{$e.JsonName | title}}Success = createAction('PROTOC_CUSTOM_{{$e.JsonName | caps}}_SUCCESS', (resolve) => {
 	return ({{$e.JsonName}}: {{$e.OutputType}}{{if $e.Repeat}}[]{{end}}) => resolve({{$e.JsonName}})


### PR DESCRIPTION
Add optional `resolve` and `reject` arguments to the standard "Request" action creators. This way the standard action creators can simply dispatch actions or be wrapped with a promise, like with the "Promise" action creators. One can still import the "Promise" ones, but they will be the exact objects, for backward-compatibility. e.g.

```js
const { getThingRequest, getThingRequestPromise } from './actions_pb';

// don't need the second import
console.log(getThingRequest === getThingRequestPromise); // true

// ... can now do instead
getThingRequest({...}, resolve, reject);
// or
getThingRequest({...}, resolve, reject);
```